### PR TITLE
:wrench: Drain queues when empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,7 @@
-0.2.1 / TBA
+0.2.0 / 2017-10-31
 ==================
 - Call drain for an empty queue
 - Use NHSUK bunyan logger
-
-0.2.0 / 2017-10-26
-==================
 - Upgrade Docker container to `node:8.8.0-alpine`
 - Update npm dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.2.1 / TBA
+==================
+- Call drain for an empty queue
+- Use NHSUK bunyan logger
+
 0.2.0 / 2017-10-26
 ==================
 - Upgrade Docker container to `node:8.8.0-alpine`

--- a/app/lib/etl-toolkit/queues/populateIds.js
+++ b/app/lib/etl-toolkit/queues/populateIds.js
@@ -59,16 +59,20 @@ function addPageToQueue(q, pageNo) {
 }
 
 function start(options) {
-  getIdsAction = options.getIdsAction;
-  const q = async.queue(processQueueItem, options.workers);
+  if (options.totalPages > 0) {
+    getIdsAction = options.getIdsAction;
+    const q = async.queue(processQueueItem, options.workers);
 
-  q.drain = () => {
-    saveState();
+    q.drain = () => {
+      saveState();
+      options.queueComplete();
+    };
+
+    for (let i = 1; i <= options.totalPages; i++) {
+      addPageToQueue(q, i);
+    }
+  } else {
     options.queueComplete();
-  };
-
-  for (let i = 1; i <= options.totalPages; i++) {
-    addPageToQueue(q, i);
   }
 }
 

--- a/app/lib/etl-toolkit/queues/populateRecordsFromIds.js
+++ b/app/lib/etl-toolkit/queues/populateRecordsFromIds.js
@@ -84,14 +84,18 @@ function startRetryQueue(options) {
 
 function start(options) {
   count = 0;
-  populateRecordFromIdAction = options.populateRecordAction;
-  setHitsPerWorker(options);
-  const q = async.queue(processQueueItem, options.workers);
-  queueIds(q);
-  q.drain = () => {
-    etlStore.saveState();
+  if (etlStore.getIds().length > 0) {
+    populateRecordFromIdAction = options.populateRecordAction;
+    setHitsPerWorker(options);
+    const q = async.queue(processQueueItem, options.workers);
+    queueIds(q);
+    q.drain = () => {
+      etlStore.saveState();
+      options.queueComplete();
+    };
+  } else {
     options.queueComplete();
-  };
+  }
 }
 
 module.exports = {

--- a/app/lib/logger.js
+++ b/app/lib/logger.js
@@ -1,16 +1,1 @@
-const bunyan = require('bunyan');
-
-const log = bunyan.createLogger({ name: 'pharmacy-data-etl' });
-
-function info(message) {
-  log.info(message);
-}
-
-function error(message, err) {
-  log.error(message, err);
-}
-
-module.exports = {
-  info,
-  error,
-};
+module.exports = require('nhsuk-bunyan-logger')('pharmacy-data-etl');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pharmacy-data-etl",
-  "version": "0.2.1",
+  "version": "0.2.0",
   "description": "ETL to extract data from Syndication/Organisations and store as JSON",
   "main": "app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-mocha": "^4.11.0",
     "eslint-watch": "^3.1.2",
     "husky": "^0.14.2",
-    "istanbul": "^0.4.5",
+    "istanbul": "^1.1.0-alpha.1",
     "mocha": "^4.0.0",
     "nock": "^9.0.14",
     "nodemon": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pharmacy-data-etl",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "ETL to extract data from Syndication/Organisations and store as JSON",
   "main": "app.js",
   "scripts": {
@@ -63,6 +63,7 @@
     "azure-storage": "^2.4.0",
     "bunyan": "^1.8.12",
     "google-libphonenumber": "^3.0.3",
+    "nhsuk-bunyan-logger": "^1.4.1",
     "node-schedule": "^1.2.4",
     "require-environment-variables": "^1.1.2",
     "xml2js": "^0.4.19"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
   "dependencies": {
     "async": "^2.5.0",
     "azure-storage": "^2.4.0",
-    "bunyan": "^1.8.12",
     "google-libphonenumber": "^3.0.3",
     "nhsuk-bunyan-logger": "^1.4.1",
     "node-schedule": "^1.2.4",

--- a/test/integration/etl.js
+++ b/test/integration/etl.js
@@ -1,0 +1,43 @@
+const nock = require('nock');
+const fs = require('fs');
+
+const etl = require('../../app/lib/etl');
+const config = require('../../app/lib/config');
+
+function readFile(path) {
+  return fs.readFileSync(path, 'utf8');
+}
+
+const uri = `/all.xml?apikey=${process.env.SYNDICATION_API_KEY}&page=1`;
+
+function stubResults(filePath) {
+  const stubbedData = readFile(filePath);
+  nock(config.syndicationApiUrl)
+    .get(uri)
+    .reply(200, stubbedData);
+}
+
+function stubNoResults() {
+  stubResults('test/resources/zero-pages.xml');
+}
+
+function stubOnePageOfResults() {
+  stubResults('test/resources/one-page.xml');
+}
+
+describe('ETL', function test() {
+  this.timeout(5000);
+  it('should complete ETL if no results', async () => {
+    stubNoResults();
+    await etl.start();
+  });
+
+  it('should complete ETL if one page of results', async () => {
+    stubOnePageOfResults();
+    await etl.start();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+});

--- a/test/integration/populateIds.js
+++ b/test/integration/populateIds.js
@@ -48,6 +48,18 @@ describe('Populate ID queue', () => {
     populateIds.start(options);
   });
 
+  it('should call queueComplete for zero pages', (done) => {
+    const options = {
+      workers: 1,
+      totalPages: 0,
+      getIdsAction: () => { done('should not have been called'); },
+      queueComplete: () => {
+        done();
+      },
+    };
+    populateIds.start(options);
+  });
+
   it('should ignore pages already scanned etlStore with loaded ids', (done) => {
     const queueComplete = () => {
       assertEtlStore();

--- a/test/integration/populateRecordsFromIds.js
+++ b/test/integration/populateRecordsFromIds.js
@@ -49,6 +49,18 @@ describe('Populate ID queue', () => {
     populateRecordsFromIds.start(options);
   });
 
+  it('should call queueComplete for empty ID list', (done) => {
+    etlStore.addIds([]);
+    const options = {
+      workers: 1,
+      populateRecordAction: getPharmacyAction,
+      queueComplete: () => {
+        done();
+      },
+    };
+    populateRecordsFromIds.start(options);
+  });
+
   it('should skip duplicate IDs', (done) => {
     etlStore.addIds([odsCode1, odsCode2, odsCode3, odsCode1]);
     const options = {

--- a/test/integration/populateRecordsFromIds.js
+++ b/test/integration/populateRecordsFromIds.js
@@ -11,7 +11,7 @@ const odsCode3 = 'FP3';
 
 function getPharmacyAction(odsCode) {
   return new Promise((resolve) => {
-    resolve({ _id: odsCode });
+    resolve({ identifier: odsCode });
   });
 }
 
@@ -20,7 +20,7 @@ function getPharmacyWithErrorAction(odsCode) {
     if (odsCode === odsCode2) {
       throw new Error('error in json');
     } else {
-      resolve({ _id: odsCode });
+      resolve({ identifier: odsCode });
     }
   });
 }
@@ -37,9 +37,9 @@ describe('Populate ID queue', () => {
       populateRecordAction: getPharmacyAction,
       queueComplete: () => {
         /* eslint-disable no-underscore-dangle */
-        expect(etlStore.getRecord(odsCode1)._id).to.equal(odsCode1);
-        expect(etlStore.getRecord(odsCode2)._id).to.equal(odsCode2);
-        expect(etlStore.getRecord(odsCode3)._id).to.equal(odsCode3);
+        expect(etlStore.getRecord(odsCode1).identifier).to.equal(odsCode1);
+        expect(etlStore.getRecord(odsCode2).identifier).to.equal(odsCode2);
+        expect(etlStore.getRecord(odsCode3).identifier).to.equal(odsCode3);
         expect(etlStore.getErorredIds().length).to.equal(0);
         expect(etlStore.getRecords().length).to.equal(3);
         /* eslint-enable no-underscore-dangle */
@@ -68,9 +68,9 @@ describe('Populate ID queue', () => {
       populateRecordAction: getPharmacyAction,
       queueComplete: () => {
         /* eslint-disable no-underscore-dangle */
-        expect(etlStore.getRecord(odsCode1)._id).to.equal(odsCode1);
-        expect(etlStore.getRecord(odsCode2)._id).to.equal(odsCode2);
-        expect(etlStore.getRecord(odsCode3)._id).to.equal(odsCode3);
+        expect(etlStore.getRecord(odsCode1).identifier).to.equal(odsCode1);
+        expect(etlStore.getRecord(odsCode2).identifier).to.equal(odsCode2);
+        expect(etlStore.getRecord(odsCode3).identifier).to.equal(odsCode3);
         expect(etlStore.getErorredIds().length).to.equal(0);
         expect(etlStore.getRecords().length).to.equal(3);
         /* eslint-enable no-underscore-dangle */
@@ -87,8 +87,8 @@ describe('Populate ID queue', () => {
       populateRecordAction: getPharmacyWithErrorAction,
       queueComplete: () => {
         /* eslint-disable no-underscore-dangle */
-        expect(etlStore.getRecord(odsCode1)._id).to.equal(odsCode1);
-        expect(etlStore.getRecord(odsCode3)._id).to.equal(odsCode3);
+        expect(etlStore.getRecord(odsCode1).identifier).to.equal(odsCode1);
+        expect(etlStore.getRecord(odsCode3).identifier).to.equal(odsCode3);
         expect(etlStore.getRecords().length).to.equal(2);
         expect(etlStore.getErorredIds().length).to.equal(1);
         /* eslint-enable no-underscore-dangle */
@@ -106,8 +106,8 @@ describe('Populate ID queue', () => {
       populateRecordAction: getPharmacyAction,
       queueComplete: () => {
         /* eslint-disable no-underscore-dangle */
-        expect(etlStore.getRecord(odsCode1)._id).to.equal(odsCode1);
-        expect(etlStore.getRecord(odsCode3)._id).to.equal(odsCode3);
+        expect(etlStore.getRecord(odsCode1).identifier).to.equal(odsCode1);
+        expect(etlStore.getRecord(odsCode3).identifier).to.equal(odsCode3);
         expect(etlStore.getRecords().length).to.equal(3);
         expect(etlStore.getErorredIds().length).to.equal(0);
         /* eslint-enable no-underscore-dangle */

--- a/test/resources/all-one-pharmacy-no-odscode.json
+++ b/test/resources/all-one-pharmacy-no-odscode.json
@@ -22,7 +22,7 @@
         "rel": "self",
         "type": "application/xhtml+xml",
         "title": "Overview - Tesco Instore Pharmacy - NHS Choices",
-        "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/29581?apikey=bbccdd"
+        "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/29581?apikey=CHANGEME"
       }
     }
   ],

--- a/test/resources/all-one-pharmacy.json
+++ b/test/resources/all-one-pharmacy.json
@@ -22,7 +22,7 @@
         "rel": "self",
         "type": "application/xhtml+xml",
         "title": "Overview - Tesco Instore Pharmacy - NHS Choices",
-        "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/29581?apikey=bbccdd"
+        "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/29581?apikey=CHANGEME"
       }
     }
   ],

--- a/test/resources/all-page-1.json
+++ b/test/resources/all-page-1.json
@@ -34,7 +34,7 @@
           "rel": "self",
           "type": "application/xml",
           "title": "NHS Choices - All Pharmacies",
-          "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/all?apikey=bbccdd"
+          "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/all?apikey=CHANGEME"
         }
       },
       {
@@ -43,7 +43,7 @@
           "type": "application/xml",
           "title": "first",
           "length": "1000",
-          "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/all?apikey=bbccdd&page=1"
+          "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/all?apikey=CHANGEME&page=1"
         }
       },
       {
@@ -52,7 +52,7 @@
           "type": "application/xml",
           "title": "next",
           "length": "1000",
-          "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/all?apikey=bbccdd&page=2"
+          "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/all?apikey=CHANGEME&page=2"
         }
       },
       {
@@ -61,7 +61,7 @@
           "type": "application/xml",
           "title": "last",
           "length": "1000",
-          "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/all?apikey=bbccdd&page=385"
+          "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/all?apikey=CHANGEME&page=385"
         }
       },
       {
@@ -103,7 +103,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - Tesco Instore Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/29581?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/29581?apikey=CHANGEME"
             }
           }
         ],
@@ -159,7 +159,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - 118 Pharmacy Ltd - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/55554?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/55554?apikey=CHANGEME"
             }
           }
         ],
@@ -215,7 +215,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - 1st Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/32248?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/32248?apikey=CHANGEME"
             }
           }
         ],
@@ -271,7 +271,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - 212 Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31926?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31926?apikey=CHANGEME"
             }
           }
         ],
@@ -328,7 +328,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - 247Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/7758300?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/7758300?apikey=CHANGEME"
             }
           }
         ],
@@ -383,7 +383,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - 3q Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/28129?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/28129?apikey=CHANGEME"
             }
           }
         ],
@@ -437,7 +437,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - 4court Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/35183?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/35183?apikey=CHANGEME"
             }
           }
         ],
@@ -493,7 +493,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - 4Court Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/32953?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/32953?apikey=CHANGEME"
             }
           }
         ],
@@ -549,7 +549,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - 7 - 11 Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/32147?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/32147?apikey=CHANGEME"
             }
           }
         ],
@@ -603,7 +603,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - 8 Pm Chemist Ltd - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31995?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31995?apikey=CHANGEME"
             }
           }
         ],
@@ -657,7 +657,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - A & S Shillam Limited - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/5065279?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/5065279?apikey=CHANGEME"
             }
           }
         ],
@@ -713,7 +713,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - A Akhtar - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/25563?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/25563?apikey=CHANGEME"
             }
           }
         ],
@@ -769,7 +769,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - A and A Pharmacy Ltd - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/34040?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/34040?apikey=CHANGEME"
             }
           }
         ],
@@ -823,7 +823,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - A C Moule & Co Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/4511566?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/4511566?apikey=CHANGEME"
             }
           }
         ],
@@ -877,7 +877,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - A Karim's Chuckery Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/29626?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/29626?apikey=CHANGEME"
             }
           }
         ],
@@ -932,7 +932,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - A Kassam Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31167?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31167?apikey=CHANGEME"
             }
           }
         ],
@@ -988,7 +988,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - A Moore & Co - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/34559?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/34559?apikey=CHANGEME"
             }
           }
         ],
@@ -1041,7 +1041,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - A R Chemist - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/29973?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/29973?apikey=CHANGEME"
             }
           }
         ],
@@ -1095,7 +1095,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - A T Derbyshire - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/7353571?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/7353571?apikey=CHANGEME"
             }
           }
         ],
@@ -1149,7 +1149,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - A.C. Curd Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/1279755?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/1279755?apikey=CHANGEME"
             }
           }
         ],
@@ -1202,7 +1202,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - A1 Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31369?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31369?apikey=CHANGEME"
             }
           }
         ],
@@ -1258,7 +1258,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - Aa Beggs - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/33219?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/33219?apikey=CHANGEME"
             }
           }
         ],
@@ -1314,7 +1314,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - Aa Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/4209890?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/4209890?apikey=CHANGEME"
             }
           }
         ],
@@ -1368,7 +1368,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - Abbey Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/6331522?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/6331522?apikey=CHANGEME"
             }
           }
         ],
@@ -1422,7 +1422,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - Abbey Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31900?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31900?apikey=CHANGEME"
             }
           }
         ],
@@ -1477,7 +1477,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - Abbey Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/36813?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/36813?apikey=CHANGEME"
             }
           }
         ],
@@ -1531,7 +1531,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - Abbey Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/27435?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/27435?apikey=CHANGEME"
             }
           }
         ],
@@ -1585,7 +1585,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - Abbey Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/32067?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/32067?apikey=CHANGEME"
             }
           }
         ],
@@ -1638,7 +1638,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - Abbey Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/35829?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/35829?apikey=CHANGEME"
             }
           }
         ],
@@ -1693,7 +1693,7 @@
               "rel": "self",
               "type": "application/xhtml+xml",
               "title": "Overview - Abbeydale Pharmacy - NHS Choices",
-              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/36395?apikey=bbccdd"
+              "href": "https://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/36395?apikey=CHANGEME"
             }
           }
         ],

--- a/test/resources/one-page.xml
+++ b/test/resources/one-page.xml
@@ -1,0 +1,829 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed 
+  xmlns="http://www.w3.org/2005/Atom">
+  <title type="text">NHS Choices - All Pharmacies</title>
+  <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/all</id>
+  <rights type="text">© Crown Copyright 2009</rights>
+  <updated>2017-10-26T11:23:19Z</updated>
+  <category term="pharmacies" />
+  <logo>http://www.nhs.uk/nhscwebservices/documents/logo1.jpg</logo>
+  <author>
+    <name>NHS Choices</name>
+    <uri>http://www.nhs.uk</uri>
+    <email>webservices@nhschoices.nhs.uk</email>
+  </author>
+  <link rel="self" type="application/xml" title="NHS Choices - All Pharmacies" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/all?apikey=CHANGEME" />
+  <link rel="first" type="application/xml" title="first" length="1000" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/all?apikey=CHANGEME&amp;page=1" />
+  <link rel="next" type="application/xml" title="next" length="1000" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/all?apikey=CHANGEME&amp;page=1" />
+  <link rel="last" type="application/xml" title="last" length="1000" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/all?apikey=CHANGEME&amp;page=1" />
+  <link rel="alternate" title="Find and choose services - Pharmacies" href="http://www.nhs.uk/ServiceDirectories/pages/ServiceSearch.aspx?ServiceType=Pharmacy" />
+  <tracking 
+    xmlns="http://syndication.nhschoices.nhs.uk/services">&lt;img style="border: 0; width: 1px; height: 1px;" alt="" src="http://statse.webtrendslive.com/dcss9yzisf9xjyg74mgbihg8p_8d2u/njs.gif?dcsuri=/organisations%2fpharmacies%2fall&amp;amp;wt.js=no&amp;amp;wt.cg_n=syndication"/&gt;
+  </tracking>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31926</id>
+    <title type="text">212 Pharmacy - Summary</title>
+    <published>2017-01-13T01:37:08Z</published>
+    <updated>2017-01-13T01:37:08Z</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - 212 Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=34876" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - 212 Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31926?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>212 Pharmacy</s:name>
+        <s:odscode>FN418</s:odscode>
+        <s:address>
+          <s:addressLine>Pharmacy 1st Limited</s:addressLine>
+          <s:addressLine>Pharmacy 1st</s:addressLine>
+          <s:addressLine>212 Canterbury Street</s:addressLine>
+          <s:addressLine>Gillingham</s:addressLine>
+          <s:addressLine>Kent</s:addressLine>
+          <s:postcode>ME7 5XL</s:postcode>
+        </s:address>
+        <s:phone>01634 850289</s:phone>
+        <s:email>pharmacy1st@outlook.com</s:email>
+        <s:geographicCoordinates>
+          <s:latitude>51.3800621032715</s:latitude>
+          <s:longitude>0.54780900478363</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/32147</id>
+    <title type="text">7 - 11 Pharmacy - Summary</title>
+    <published>2017-04-13T01:37:45+01:00</published>
+    <updated>2017-04-13T01:37:45+01:00</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - 7 - 11 Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=10089" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - 7 - 11 Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/32147?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>7 - 11 Pharmacy</s:name>
+        <s:odscode>FNG62</s:odscode>
+        <s:address>
+          <s:addressLine>84 Berners Street</s:addressLine>
+          <s:addressLine>Leicester</s:addressLine>
+          <s:addressLine>Leicestershire</s:addressLine>
+          <s:postcode>LE2 0FS</s:postcode>
+        </s:address>
+        <s:phone>0116 2511333</s:phone>
+        <s:geographicCoordinates>
+          <s:latitude>52.6343765258789</s:latitude>
+          <s:longitude>-1.11219882965088</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/34040</id>
+    <title type="text">A and A Pharmacy Ltd - Summary</title>
+    <published>2017-08-11T01:36:15+01:00</published>
+    <updated>2017-08-11T01:36:15+01:00</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - A and A Pharmacy Ltd - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=11816" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - A and A Pharmacy Ltd - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/34040?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>A and A Pharmacy Ltd</s:name>
+        <s:odscode>FRL97</s:odscode>
+        <s:address>
+          <s:addressLine>58 Wilmslow Road</s:addressLine>
+          <s:addressLine>Rusholme</s:addressLine>
+          <s:addressLine>Manchester</s:addressLine>
+          <s:postcode>M14 5AL</s:postcode>
+        </s:address>
+        <s:phone>0161 224 8501</s:phone>
+        <s:geographicCoordinates>
+          <s:latitude>53.454517364502</s:latitude>
+          <s:longitude>-2.22506356239319</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31167</id>
+    <title type="text">A Kassam Pharmacy - Summary</title>
+    <published>2017-04-23T01:37:07+01:00</published>
+    <updated>2017-04-23T01:37:07+01:00</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - A Kassam Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=9202" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - A Kassam Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31167?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>A Kassam Pharmacy</s:name>
+        <s:odscode>FLV47</s:odscode>
+        <s:address>
+          <s:addressLine>Kassam Pharmacy</s:addressLine>
+          <s:addressLine>77 Gales Drive</s:addressLine>
+          <s:addressLine>Three Bridges</s:addressLine>
+          <s:addressLine>Crawley</s:addressLine>
+          <s:addressLine>West Sussex</s:addressLine>
+          <s:postcode>RH10 1QA</s:postcode>
+        </s:address>
+        <s:phone>01293 522919</s:phone>
+        <s:geographicCoordinates>
+          <s:latitude>51.11767578125</s:latitude>
+          <s:longitude>-0.172527804970741</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/1279755</id>
+    <title type="text">A.C. Curd Pharmacy - Summary</title>
+    <published>2013-11-01T02:40:13Z</published>
+    <updated>2013-11-01T02:40:13Z</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - A.C. Curd Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=96055" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - A.C. Curd Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/1279755?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>A.C. Curd Pharmacy</s:name>
+        <s:odscode>FJ888</s:odscode>
+        <s:address>
+          <s:addressLine>55 South Street</s:addressLine>
+          <s:addressLine>Isleworth</s:addressLine>
+          <s:addressLine>Middlesex</s:addressLine>
+          <s:postcode>TW7 7AA</s:postcode>
+        </s:address>
+        <s:geographicCoordinates>
+          <s:latitude>51.4686698913574</s:latitude>
+          <s:longitude>-0.327812999486923</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/8127833</id>
+    <title type="text">Abbey Field Pharmacy - Summary</title>
+    <published>2017-09-05T05:42:51+01:00</published>
+    <updated>2017-09-05T05:42:51+01:00</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - Abbey Field Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=132840" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - Abbey Field Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/8127833?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>Abbey Field Pharmacy</s:name>
+        <s:odscode>FTA74</s:odscode>
+        <s:address>
+          <s:addressLine>Abbey Field Medical Ctr</s:addressLine>
+          <s:addressLine>Ypres Road</s:addressLine>
+          <s:addressLine>Colchester</s:addressLine>
+          <s:addressLine>Essex</s:addressLine>
+          <s:postcode>CO2 7UW</s:postcode>
+        </s:address>
+        <s:phone>01206 560 273</s:phone>
+        <s:email>info@abbeyfieldpharmacy.co.uk</s:email>
+        <s:geographicCoordinates>
+          <s:latitude>51.8776168823242</s:latitude>
+          <s:longitude>0.899742066860199</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/32067</id>
+    <title type="text">Abbey Pharmacy - Summary</title>
+    <published>2017-03-24T01:05:08Z</published>
+    <updated>2017-03-24T01:05:08Z</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - Abbey Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=10015" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - Abbey Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/32067?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>Abbey Pharmacy</s:name>
+        <s:odscode>FNC86</s:odscode>
+        <s:address>
+          <s:addressLine>313 Stockbrook Street</s:addressLine>
+          <s:addressLine>Derby</s:addressLine>
+          <s:postcode>DE22 3WH</s:postcode>
+        </s:address>
+        <s:phone>01332 291353</s:phone>
+        <s:geographicCoordinates>
+          <s:latitude>52.9158706665039</s:latitude>
+          <s:longitude>-1.49315106868744</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/32248</id>
+    <title type="text">1st Pharmacy - Summary</title>
+    <published>2017-04-23T01:37:07+01:00</published>
+    <updated>2017-04-23T01:37:07+01:00</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - 1st Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=10184" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - 1st Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/32248?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>1st Pharmacy</s:name>
+        <s:odscode>FNM60</s:odscode>
+        <s:address>
+          <s:addressLine>Fountain Hall</s:addressLine>
+          <s:addressLine>Fountain Street</s:addressLine>
+          <s:addressLine>Bradford</s:addressLine>
+          <s:addressLine>West Yorkshire</s:addressLine>
+          <s:postcode>BD1 3RA</s:postcode>
+        </s:address>
+        <s:phone>01274 323877</s:phone>
+        <s:email>1stpharmacybradford@gmail.com</s:email>
+        <s:geographicCoordinates>
+          <s:latitude>53.7972755432129</s:latitude>
+          <s:longitude>-1.75778746604919</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/32953</id>
+    <title type="text">4Court Pharmacy - Summary</title>
+    <published>2017-04-20T01:37:05+01:00</published>
+    <updated>2017-04-20T01:37:05+01:00</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - 4Court Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=10825" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - 4Court Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/32953?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>4Court Pharmacy</s:name>
+        <s:odscode>FPT24</s:odscode>
+        <s:address>
+          <s:addressLine>4Court Pharmacy</s:addressLine>
+          <s:addressLine>Blackburn Service Station</s:addressLine>
+          <s:addressLine>Whalley Banks</s:addressLine>
+          <s:addressLine>Blackburn</s:addressLine>
+          <s:postcode>BB2 1NT</s:postcode>
+        </s:address>
+        <s:phone>01254 677447</s:phone>
+        <s:email>4courtltd@gmail.com</s:email>
+        <s:geographicCoordinates>
+          <s:latitude>53.7434997558594</s:latitude>
+          <s:longitude>-2.49203658103943</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/25563</id>
+    <title type="text">A Akhtar - Summary</title>
+    <published>2014-07-18T02:40:10+01:00</published>
+    <updated>2014-07-18T02:40:10+01:00</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - A Akhtar - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=30273" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - A Akhtar - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/25563?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>A Akhtar</s:name>
+        <s:odscode>FAV78</s:odscode>
+        <s:address>
+          <s:addressLine>68 The Strand</s:addressLine>
+          <s:addressLine>Longton</s:addressLine>
+          <s:addressLine>Stoke On Trent</s:addressLine>
+          <s:addressLine>Staffordshire</s:addressLine>
+          <s:postcode>ST3 2NR</s:postcode>
+        </s:address>
+        <s:phone>01782 342955</s:phone>
+        <s:email>waterloopharmacy68@gmail.com</s:email>
+        <s:geographicCoordinates>
+          <s:latitude>52.9872207641602</s:latitude>
+          <s:longitude>-2.13689780235291</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/29626</id>
+    <title type="text">A Karim's Chuckery Pharmacy - Summary</title>
+    <published>2016-04-16T01:37:01+01:00</published>
+    <updated>2016-04-16T01:37:01+01:00</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - A Karim's Chuckery Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=46818" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - A Karim's Chuckery Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/29626?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>A Karim's Chuckery Pharmacy</s:name>
+        <s:odscode>FJD82</s:odscode>
+        <s:address>
+          <s:addressLine>7-9 Kinnerley Street</s:addressLine>
+          <s:addressLine>The Chuckery</s:addressLine>
+          <s:addressLine>Walsall</s:addressLine>
+          <s:postcode>WS1 2LD</s:postcode>
+        </s:address>
+        <s:phone>01922 613786</s:phone>
+        <s:email>chuckerypharmacy@gmail.com</s:email>
+        <s:geographicCoordinates>
+          <s:latitude>52.5806312561035</s:latitude>
+          <s:longitude>-1.96958541870117</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/7353571</id>
+    <title type="text">A T Derbyshire - Summary</title>
+    <published>2017-03-17T01:05:07Z</published>
+    <updated>2017-03-17T01:05:07Z</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - A T Derbyshire - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=128384" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - A T Derbyshire - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/7353571?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>A T Derbyshire</s:name>
+        <s:odscode>FTF41</s:odscode>
+        <s:address>
+          <s:addressLine>115 Higher Parr Street</s:addressLine>
+          <s:addressLine>St.Helens</s:addressLine>
+          <s:addressLine>Merseyside</s:addressLine>
+          <s:postcode>WA9 1AG</s:postcode>
+        </s:address>
+        <s:phone>01744 21150</s:phone>
+        <s:geographicCoordinates>
+          <s:latitude>53.4539756774902</s:latitude>
+          <s:longitude>-2.7209529876709</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/4209890</id>
+    <title type="text">Aa Pharmacy - Summary</title>
+    <published>2017-03-10T01:05:07Z</published>
+    <updated>2017-03-10T01:05:07Z</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - Aa Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=109355" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - Aa Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/4209890?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>Aa Pharmacy</s:name>
+        <s:odscode>FHW69</s:odscode>
+        <s:address>
+          <s:addressLine>98 Whitmore Way</s:addressLine>
+          <s:addressLine>Basildon</s:addressLine>
+          <s:addressLine>Essex</s:addressLine>
+          <s:postcode>SS14 3JT</s:postcode>
+        </s:address>
+        <s:phone>01268 520387</s:phone>
+        <s:geographicCoordinates>
+          <s:latitude>51.5823211669922</s:latitude>
+          <s:longitude>0.48672941327095</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/6331522</id>
+    <title type="text">Abbey Pharmacy - Summary</title>
+    <published>2017-04-21T01:05:21+01:00</published>
+    <updated>2017-04-21T01:05:21+01:00</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - Abbey Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=121307" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - Abbey Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/6331522?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>Abbey Pharmacy</s:name>
+        <s:odscode>FXX86</s:odscode>
+        <s:address>
+          <s:addressLine>19-21 Howard Street</s:addressLine>
+          <s:addressLine>Rotherham</s:addressLine>
+          <s:addressLine>South Yorkshire</s:addressLine>
+          <s:postcode>S65 1JQ</s:postcode>
+        </s:address>
+        <s:phone>01709 377421</s:phone>
+        <s:geographicCoordinates>
+          <s:latitude>53.4322242736816</s:latitude>
+          <s:longitude>-1.35464036464691</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/55554</id>
+    <title type="text">118 Pharmacy Ltd - Summary</title>
+    <published>2017-04-14T01:05:15+01:00</published>
+    <updated>2017-04-14T01:05:15+01:00</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - 118 Pharmacy Ltd - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=84926" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - 118 Pharmacy Ltd - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/55554?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>118 Pharmacy Ltd</s:name>
+        <s:odscode>FWP52</s:odscode>
+        <s:address>
+          <s:addressLine>9 High Street</s:addressLine>
+          <s:addressLine>Walsall Wood</s:addressLine>
+          <s:addressLine>Walsall</s:addressLine>
+          <s:addressLine>West Midlands</s:addressLine>
+          <s:postcode>WS9 9LR</s:postcode>
+        </s:address>
+        <s:phone>01543 379777</s:phone>
+        <s:email>info@118pharmacy.com</s:email>
+        <s:geographicCoordinates>
+          <s:latitude>52.6252212524414</s:latitude>
+          <s:longitude>-1.93311035633087</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/35183</id>
+    <title type="text">4court Pharmacy - Summary</title>
+    <published>2017-02-05T01:37:13Z</published>
+    <updated>2017-02-05T01:37:13Z</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - 4court Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=29396" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - 4court Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/35183?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>4court Pharmacy</s:name>
+        <s:odscode>FVG90</s:odscode>
+        <s:address>
+          <s:addressLine>Heybrook Service Station</s:addressLine>
+          <s:addressLine>Halifax Road</s:addressLine>
+          <s:addressLine>Rochdale</s:addressLine>
+          <s:addressLine>Lancashire</s:addressLine>
+          <s:postcode>OL16 2NT</s:postcode>
+        </s:address>
+        <s:phone>01706 646262</s:phone>
+        <s:email>4courtrochdale@gmail.com</s:email>
+        <s:geographicCoordinates>
+          <s:latitude>53.6236000061035</s:latitude>
+          <s:longitude>-2.14388132095337</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/5065279</id>
+    <title type="text">A &amp; S Shillam Limited - Summary</title>
+    <published>2016-04-21T01:37:02+01:00</published>
+    <updated>2016-04-21T01:37:02+01:00</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - A &amp; S Shillam Limited - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=113645" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - A &amp; S Shillam Limited - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/5065279?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>A &amp; S Shillam Limited</s:name>
+        <s:odscode>FEP23</s:odscode>
+        <s:address>
+          <s:addressLine>Dane Pharmacy</s:addressLine>
+          <s:addressLine>10 Dane Road</s:addressLine>
+          <s:addressLine>Seaford</s:addressLine>
+          <s:addressLine>East Sussex</s:addressLine>
+          <s:postcode>BN25 1LL</s:postcode>
+        </s:address>
+        <s:phone>01323 892660</s:phone>
+        <s:email>daneroad@shillampharmacies.com</s:email>
+        <s:geographicCoordinates>
+          <s:latitude>50.7725296020508</s:latitude>
+          <s:longitude>0.100091241300106</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/34284</id>
+    <title type="text">A E Hobbs Ltd - Summary</title>
+    <published>2017-09-05T05:42:51+01:00</published>
+    <updated>2017-09-05T05:42:51+01:00</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - A E Hobbs Ltd - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=12032" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - A E Hobbs Ltd - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/34284?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>A E Hobbs Ltd</s:name>
+        <s:odscode>FT200</s:odscode>
+        <s:address>
+          <s:addressLine>72 Mount Pleasant</s:addressLine>
+          <s:addressLine>Tunbridge Wells</s:addressLine>
+          <s:addressLine>Kent</s:addressLine>
+          <s:postcode>TN1 1RJ</s:postcode>
+        </s:address>
+        <s:phone>01892 546565</s:phone>
+        <s:email>aehobbstunbridgewells@nhs.net</s:email>
+        <s:geographicCoordinates>
+          <s:latitude>51.1319046020508</s:latitude>
+          <s:longitude>0.263678312301636</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/29973</id>
+    <title type="text">A R Chemist - Summary</title>
+    <published>2017-10-10T01:36:46+01:00</published>
+    <updated>2017-10-10T01:36:46+01:00</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - A R Chemist - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=8111" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - A R Chemist - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/29973?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>A R Chemist</s:name>
+        <s:odscode>FK012</s:odscode>
+        <s:address>
+          <s:addressLine>176-178 Old Kent Road</s:addressLine>
+          <s:addressLine>London</s:addressLine>
+          <s:postcode>SE1 5TY</s:postcode>
+        </s:address>
+        <s:phone>02077034097</s:phone>
+        <s:geographicCoordinates>
+          <s:latitude>51.4904518127441</s:latitude>
+          <s:longitude>-0.0812571048736572</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/33219</id>
+    <title type="text">Aa Beggs - Summary</title>
+    <published>2013-01-08T04:30:24Z</published>
+    <updated>2013-01-08T04:30:24Z</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - Aa Beggs - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=11065" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - Aa Beggs - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/33219?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>Aa Beggs</s:name>
+        <s:odscode>FQ951</s:odscode>
+        <s:address>
+          <s:addressLine>Beggs Pharmacy</s:addressLine>
+          <s:addressLine>32 Pencester Road</s:addressLine>
+          <s:addressLine>Dover</s:addressLine>
+          <s:addressLine>Kent</s:addressLine>
+          <s:postcode>CT16 1BW</s:postcode>
+        </s:address>
+        <s:phone>01304 205406</s:phone>
+        <s:email>beggsdover@paydens.com</s:email>
+        <s:geographicCoordinates>
+          <s:latitude>51.1274909973145</s:latitude>
+          <s:longitude>1.31211173534393</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/35829</id>
+    <title type="text">Abbey Pharmacy - Summary</title>
+    <published>2017-03-09T01:37:12Z</published>
+    <updated>2017-03-09T01:37:12Z</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - Abbey Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=13380" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - Abbey Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/35829?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>Abbey Pharmacy</s:name>
+        <s:odscode>FWJ80</s:odscode>
+        <s:address>
+          <s:addressLine>12a Abbey Parade</s:addressLine>
+          <s:addressLine>Merton High Street</s:addressLine>
+          <s:addressLine>Merton</s:addressLine>
+          <s:postcode>SW19 1DG</s:postcode>
+        </s:address>
+        <s:phone>020 85423713</s:phone>
+        <s:email>abbey@pearlchemistgroup.co.uk</s:email>
+        <s:geographicCoordinates>
+          <s:latitude>51.4159355163574</s:latitude>
+          <s:longitude>-0.185506969690323</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31900</id>
+    <title type="text">Abbey Pharmacy - Summary</title>
+    <published>2016-11-01T05:13:16Z</published>
+    <updated>2016-11-01T05:13:16Z</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - Abbey Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=9868" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - Abbey Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31900?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>Abbey Pharmacy</s:name>
+        <s:odscode>FN288</s:odscode>
+        <s:address>
+          <s:addressLine>63 Central Avenue</s:addressLine>
+          <s:addressLine>Nottingham</s:addressLine>
+          <s:addressLine>Nottinghamshire</s:addressLine>
+          <s:postcode>NG9 2QP</s:postcode>
+        </s:address>
+        <s:phone>01159 254522</s:phone>
+        <s:email>abbey@jardinesuk.com</s:email>
+        <s:geographicCoordinates>
+          <s:latitude>52.9331169128418</s:latitude>
+          <s:longitude>-1.2199147939682</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/29581</id>
+    <title type="text">Tesco Instore Pharmacy - Summary</title>
+    <published>2014-02-12T03:31:19Z</published>
+    <updated>2014-02-12T03:31:19Z</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - Tesco Instore Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=34574" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - Tesco Instore Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/29581?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>Tesco Instore Pharmacy</s:name>
+        <s:odscode>FJA60</s:odscode>
+        <s:address>
+          <s:addressLine>Tesco Pharmacy</s:addressLine>
+          <s:addressLine>Ashley Retail Park</s:addressLine>
+          <s:addressLine>Lugsdale Road</s:addressLine>
+          <s:addressLine>Widnes</s:addressLine>
+          <s:addressLine>Cheshire</s:addressLine>
+          <s:postcode>WA8 7YT</s:postcode>
+        </s:address>
+        <s:phone>0345 6719466</s:phone>
+        <s:geographicCoordinates>
+          <s:latitude>53.3623695373535</s:latitude>
+          <s:longitude>-2.72535586357117</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/28129</id>
+    <title type="text">3q Pharmacy - Summary</title>
+    <published>2017-10-03T05:16:58+01:00</published>
+    <updated>2017-10-03T05:16:58+01:00</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - 3q Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=29196" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - 3q Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/28129?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>3q Pharmacy</s:name>
+        <s:odscode>FG039</s:odscode>
+        <s:address>
+          <s:addressLine>3 Queen Street</s:addressLine>
+          <s:addressLine>Wellingborough</s:addressLine>
+          <s:addressLine>Northamptonshire</s:addressLine>
+          <s:postcode>NN8 4RW</s:postcode>
+        </s:address>
+        <s:phone>01933 273373</s:phone>
+        <s:email>3qpharmacy@gmail.com</s:email>
+        <s:geographicCoordinates>
+          <s:latitude>52.3033981323242</s:latitude>
+          <s:longitude>-0.695552706718445</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31995</id>
+    <title type="text">8 Pm Chemist Ltd - Summary</title>
+    <published>2013-01-18T05:55:04Z</published>
+    <updated>2013-01-18T05:55:04Z</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - 8 Pm Chemist Ltd - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=9949" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - 8 Pm Chemist Ltd - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31995?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>8 Pm Chemist Ltd</s:name>
+        <s:odscode>FN736</s:odscode>
+        <s:address>
+          <s:addressLine>61 Wolverhampton Street</s:addressLine>
+          <s:addressLine>Willenhall</s:addressLine>
+          <s:addressLine>West Midlands</s:addressLine>
+          <s:postcode>WV13 2NF</s:postcode>
+        </s:address>
+        <s:phone>01902 633310</s:phone>
+        <s:geographicCoordinates>
+          <s:latitude>52.5842361450195</s:latitude>
+          <s:longitude>-2.0568675994873</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/4511566</id>
+    <title type="text">A C Moule &amp; Co Pharmacy - Summary</title>
+    <published>2017-03-10T01:05:07Z</published>
+    <updated>2017-03-10T01:05:07Z</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - A C Moule &amp; Co Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=110145" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - A C Moule &amp; Co Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/4511566?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>A C Moule &amp; Co Pharmacy</s:name>
+        <s:odscode>FK058</s:odscode>
+        <s:address>
+          <s:addressLine>55 Parliament Road</s:addressLine>
+          <s:addressLine>Middlesbrough</s:addressLine>
+          <s:addressLine>Cleveland</s:addressLine>
+          <s:postcode>TS1 4JW</s:postcode>
+        </s:address>
+        <s:phone>01642 244717</s:phone>
+        <s:geographicCoordinates>
+          <s:latitude>54.5685806274414</s:latitude>
+          <s:longitude>-1.24734997749329</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/34559</id>
+    <title type="text">A Moore &amp; Co - Summary</title>
+    <published>2017-10-20T01:05:16+01:00</published>
+    <updated>2017-10-20T01:05:16+01:00</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - A Moore &amp; Co - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=12281" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - A Moore &amp; Co - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/34559?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>A Moore &amp; Co</s:name>
+        <s:odscode>FTH32</s:odscode>
+        <s:address>
+          <s:addressLine>25E Lowndes Street</s:addressLine>
+          <s:addressLine>London</s:addressLine>
+          <s:postcode>SW1X 9JF</s:postcode>
+        </s:address>
+        <s:phone>020 72355887</s:phone>
+        <s:geographicCoordinates>
+          <s:latitude>51.4987297058105</s:latitude>
+          <s:longitude>-0.157903060317039</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31369</id>
+    <title type="text">A1 Pharmacy - Summary</title>
+    <published>2017-01-08T01:37:15Z</published>
+    <updated>2017-01-08T01:37:15Z</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - A1 Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=29273" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - A1 Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/31369?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>A1 Pharmacy</s:name>
+        <s:odscode>FM664</s:odscode>
+        <s:address>
+          <s:addressLine>491 Radcliffe Road</s:addressLine>
+          <s:addressLine>Darcy Lever</s:addressLine>
+          <s:addressLine>Bolton</s:addressLine>
+          <s:addressLine>BOLTON</s:addressLine>
+          <s:postcode>BL3 1SX</s:postcode>
+        </s:address>
+        <s:phone>01204 363400 (ext. 1204363400)</s:phone>
+        <s:email>info@a1-pharmacy.co.uk</s:email>
+        <s:geographicCoordinates>
+          <s:latitude>53.57080078125</s:latitude>
+          <s:longitude>-2.39486575126648</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/36813</id>
+    <title type="text">Abbey Pharmacy - Summary</title>
+    <published>2013-01-08T04:30:24Z</published>
+    <updated>2013-01-08T04:30:24Z</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - Abbey Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=14254" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - Abbey Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/36813?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>Abbey Pharmacy</s:name>
+        <s:odscode>FYE27</s:odscode>
+        <s:address>
+          <s:addressLine>45 High Street</s:addressLine>
+          <s:addressLine>Abbots Langley</s:addressLine>
+          <s:addressLine>Hertfordshire</s:addressLine>
+          <s:postcode>WD5 0AA</s:postcode>
+        </s:address>
+        <s:phone>01923 262151</s:phone>
+        <s:geographicCoordinates>
+          <s:latitude>51.7072296142578</s:latitude>
+          <s:longitude>-0.416392683982849</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+  <entry>
+    <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/27435</id>
+    <title type="text">Abbey Pharmacy - Summary</title>
+    <published>2016-06-23T01:37:01+01:00</published>
+    <updated>2016-06-23T01:37:01+01:00</updated>
+    <link rel="alternate" type="application/xhtml" title="Overview - Abbey Pharmacy - NHS Choices" href="http://www.nhs.uk/Services/pharmacies/Overview/DefaultView.aspx?id=34794" />
+    <link rel="self" type="application/xhtml+xml" title="Overview - Abbey Pharmacy - NHS Choices" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/27435?apikey=CHANGEME" />
+    <content type="application/xml">
+      <s:organisationSummary 
+        xmlns:s="http://syndication.nhschoices.nhs.uk/services">
+        <s:name>Abbey Pharmacy</s:name>
+        <s:odscode>FET80</s:odscode>
+        <s:address>
+          <s:addressLine>The Guildhall Surgery</s:addressLine>
+          <s:addressLine>Lower Baxter Street</s:addressLine>
+          <s:addressLine>Bury St Edmunds</s:addressLine>
+          <s:postcode>IP33 1ET</s:postcode>
+        </s:address>
+        <s:phone>01284 761769</s:phone>
+        <s:geographicCoordinates>
+          <s:latitude>52.2453918457031</s:latitude>
+          <s:longitude>0.71503746509552</s:longitude>
+        </s:geographicCoordinates>
+      </s:organisationSummary>
+    </content>
+  </entry>
+</feed>

--- a/test/resources/zero-pages.xml
+++ b/test/resources/zero-pages.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed 
+  xmlns="http://www.w3.org/2005/Atom">
+  <title type="text">NHS Choices - All Pharmacies</title>
+  <id>http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/all</id>
+  <rights type="text">© Crown Copyright 2009</rights>
+  <updated>2017-10-26T11:23:19Z</updated>
+  <category term="pharmacies" />
+  <logo>http://www.nhs.uk/nhscwebservices/documents/logo1.jpg</logo>
+  <author>
+    <name>NHS Choices</name>
+    <uri>http://www.nhs.uk</uri>
+    <email>webservices@nhschoices.nhs.uk</email>
+  </author>
+  <link rel="self" type="application/xml" title="NHS Choices - All Pharmacies" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/all?apikey=CHANGEME" />
+  <link rel="first" type="application/xml" title="first" length="1000" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/all?apikey=CHANGEME&amp;page=0" />
+  <link rel="next" type="application/xml" title="next" length="1000" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/all?apikey=CHANGEME&amp;page=0" />
+  <link rel="last" type="application/xml" title="last" length="1000" href="http://v1.syndication.nhschoices.nhs.uk/organisations/pharmacies/all?apikey=CHANGEME&amp;page=0" />
+  <link rel="alternate" title="Find and choose services - Pharmacies" href="http://www.nhs.uk/ServiceDirectories/pages/ServiceSearch.aspx?ServiceType=Pharmacy" />
+  <tracking 
+    xmlns="http://syndication.nhschoices.nhs.uk/services">&lt;img style="border: 0; width: 1px; height: 1px;" alt="" src="http://statse.webtrendslive.com/dcss9yzisf9xjyg74mgbihg8p_8d2u/njs.gif?dcsuri=/organisations%2fpharmacies%2fall&amp;amp;wt.js=no&amp;amp;wt.cg_n=syndication"/&gt;
+  </tracking>
+</feed>

--- a/yarn.lock
+++ b/yarn.lock
@@ -338,7 +338,7 @@ builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
-bunyan@^1.8.12:
+bunyan@^1.8.10, bunyan@^1.8.12:
   version "1.8.12"
   resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.12.tgz#f150f0f6748abdd72aeae84f04403be2ef113797"
   optionalDependencies:
@@ -2347,6 +2347,13 @@ nested-error-stacks@^1.0.0:
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz#19f619591519f096769a5ba9a86e6eeec823c3cf"
   dependencies:
     inherits "~2.0.1"
+
+nhsuk-bunyan-logger@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/nhsuk-bunyan-logger/-/nhsuk-bunyan-logger-1.4.1.tgz#cc57ef81fc326febc7d7f68520e0a1ac784c4733"
+  dependencies:
+    bunyan "^1.8.10"
+    is-nan "^1.2.1"
 
 nock@^9.0.14:
   version "9.0.25"

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,6 +104,12 @@ anymatch@^1.3.0:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
 
+append-transform@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
+  dependencies:
+    default-require-extensions "^1.0.0"
+
 aproba@^1.0.3:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.1.2.tgz#45c6629094de4e96f693ef7eab74ae079c240fc1"
@@ -181,7 +187,7 @@ async@1.x, async@^1.4.0, async@~1.5:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.5.0:
+async@^2.1.4, async@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
   dependencies:
@@ -223,13 +229,32 @@ azure-storage@^2.4.0:
     xml2js "0.2.7"
     xmlbuilder "0.4.3"
 
-babel-code-frame@^6.22.0:
+babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
     chalk "^1.1.3"
     esutils "^2.0.2"
     js-tokens "^3.0.2"
+
+babel-generator@^6.18.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.0.tgz#ac1ae20070b79f6e3ca1d3269613053774f20dc5"
+  dependencies:
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    detect-indent "^4.0.0"
+    jsesc "^1.3.0"
+    lodash "^4.17.4"
+    source-map "^0.5.6"
+    trim-right "^1.0.1"
+
+babel-messages@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
+  dependencies:
+    babel-runtime "^6.22.0"
 
 babel-polyfill@^6.20.0:
   version "6.26.0"
@@ -239,12 +264,49 @@ babel-polyfill@^6.20.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-runtime@^6.26.0:
+babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
+
+babel-template@^6.16.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    lodash "^4.17.4"
+
+babel-traverse@^6.18.0, babel-traverse@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    debug "^2.6.8"
+    globals "^9.18.0"
+    invariant "^2.2.2"
+    lodash "^4.17.4"
+
+babel-types@^6.18.0, babel-types@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
+  dependencies:
+    babel-runtime "^6.26.0"
+    esutils "^2.0.2"
+    lodash "^4.17.4"
+    to-fast-properties "^1.0.3"
+
+babylon@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -671,7 +733,7 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug@3.1.0, debug@^3.0.1:
+debug@3.1.0, debug@^3.0.1, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -717,6 +779,12 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+default-require-extensions@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
+  dependencies:
+    strip-bom "^2.0.0"
+
 define-properties@^1.1.1, define-properties@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
@@ -747,6 +815,12 @@ delayed-stream@~1.0.0:
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+
+detect-indent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
+  dependencies:
+    repeating "^2.0.0"
 
 diff@3.3.1:
   version "3.3.1"
@@ -886,17 +960,6 @@ es6-promise@^3.0.2, es6-promise@^3.1.2, es6-promise@^3.3.1:
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-
-escodegen@1.8.x:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.8.1.tgz#5a5b53af4693110bebb0867aa3430dd3b70a1018"
-  dependencies:
-    esprima "^2.7.1"
-    estraverse "^1.9.1"
-    esutils "^2.0.2"
-    optionator "^0.8.1"
-  optionalDependencies:
-    source-map "~0.2.0"
 
 eslint-config-airbnb-base@^12.0.0:
   version "12.1.0"
@@ -1047,10 +1110,6 @@ espree@^3.5.1:
     acorn "^5.1.1"
     acorn-jsx "^3.0.0"
 
-esprima@2.7.x, esprima@^2.7.1:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
-
 esprima@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
@@ -1067,10 +1126,6 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
     object-assign "^4.0.1"
-
-estraverse@^1.9.1:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
 
 estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
@@ -1181,6 +1236,13 @@ file-entry-cache@^2.0.0:
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
+
+fileset@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/fileset/-/fileset-2.0.3.tgz#8e7548a96d3cc2327ee5e674168723a333bba2a0"
+  dependencies:
+    glob "^7.0.3"
+    minimatch "^3.0.3"
 
 fill-range@^2.1.0:
   version "2.2.3"
@@ -1363,16 +1425,6 @@ glob@7.1.2, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@~7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^5.0.15:
-  version "5.0.15"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 glob@^6.0.1:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
@@ -1383,7 +1435,7 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.17.0:
+globals@^9.17.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
@@ -1467,9 +1519,9 @@ growl@1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
 
-handlebars@^4.0.1:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.10.tgz#3d30c718b09a3d96f23ea4cc1f403c4d3ba9ff4f"
+handlebars@^4.0.3:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
   dependencies:
     async "^1.4.0"
     optimist "^0.6.1"
@@ -1680,6 +1732,12 @@ inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
+invariant@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
+  dependencies:
+    loose-envify "^1.0.0"
+
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
@@ -1884,30 +1942,87 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-istanbul@^0.4.5:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/istanbul/-/istanbul-0.4.5.tgz#65c7d73d4c4da84d4f3ac310b918fb0b8033733b"
+istanbul-api@^1.1.0-alpha:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.2.1.tgz#0c60a0515eb11c7d65c6b50bba2c6e999acd8620"
+  dependencies:
+    async "^2.1.4"
+    fileset "^2.0.2"
+    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-hook "^1.1.0"
+    istanbul-lib-instrument "^1.9.1"
+    istanbul-lib-report "^1.1.2"
+    istanbul-lib-source-maps "^1.2.2"
+    istanbul-reports "^1.1.3"
+    js-yaml "^3.7.0"
+    mkdirp "^0.5.1"
+    once "^1.4.0"
+
+istanbul-lib-coverage@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz#73bfb998885299415c93d38a3e9adf784a77a9da"
+
+istanbul-lib-hook@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz#8538d970372cb3716d53e55523dd54b557a8d89b"
+  dependencies:
+    append-transform "^0.4.0"
+
+istanbul-lib-instrument@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz#250b30b3531e5d3251299fdd64b0b2c9db6b558e"
+  dependencies:
+    babel-generator "^6.18.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.18.0"
+    babel-types "^6.18.0"
+    babylon "^6.18.0"
+    istanbul-lib-coverage "^1.1.1"
+    semver "^5.3.0"
+
+istanbul-lib-report@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz#922be27c13b9511b979bd1587359f69798c1d425"
+  dependencies:
+    istanbul-lib-coverage "^1.1.1"
+    mkdirp "^0.5.1"
+    path-parse "^1.0.5"
+    supports-color "^3.1.2"
+
+istanbul-lib-source-maps@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz#750578602435f28a0c04ee6d7d9e0f2960e62c1c"
+  dependencies:
+    debug "^3.1.0"
+    istanbul-lib-coverage "^1.1.1"
+    mkdirp "^0.5.1"
+    rimraf "^2.6.1"
+    source-map "^0.5.3"
+
+istanbul-reports@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.3.tgz#3b9e1e8defb6d18b1d425da8e8b32c5a163f2d10"
+  dependencies:
+    handlebars "^4.0.3"
+
+istanbul@^1.1.0-alpha.1:
+  version "1.1.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/istanbul/-/istanbul-1.1.0-alpha.1.tgz#781795656018a2174c5f60f367ee5d361cb57b77"
   dependencies:
     abbrev "1.0.x"
     async "1.x"
-    escodegen "1.8.x"
-    esprima "2.7.x"
-    glob "^5.0.15"
-    handlebars "^4.0.1"
+    istanbul-api "^1.1.0-alpha"
     js-yaml "3.x"
     mkdirp "0.5.x"
     nopt "3.x"
-    once "1.x"
-    resolve "1.1.x"
-    supports-color "^3.1.0"
     which "^1.1.1"
     wordwrap "^1.0.0"
 
-js-tokens@^3.0.2:
+js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@3.x, js-yaml@^3.5.3, js-yaml@^3.6.1, js-yaml@^3.9.1:
+js-yaml@3.x, js-yaml@^3.5.3, js-yaml@^3.6.1, js-yaml@^3.7.0, js-yaml@^3.9.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -1921,6 +2036,10 @@ jsbn@~0.1.0:
 jschardet@^1.4.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.5.1.tgz#c519f629f86b3a5bedba58a88d311309eec097f9"
+
+jsesc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
 
 jshint@^2.8.0:
   version "2.9.5"
@@ -2176,6 +2295,12 @@ long-timeout@0.1.1:
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
+
+loose-envify@^1.0.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  dependencies:
+    js-tokens "^3.0.0"
 
 lowercase-keys@^1.0.0:
   version "1.0.0"
@@ -2495,7 +2620,7 @@ object.omit@^2.0.0:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
 
-once@1.x, once@^1.3.0, once@^1.3.3, once@^1.4.0:
+once@^1.3.0, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -2522,7 +2647,7 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.1, optionator@^0.8.2:
+optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -2989,10 +3114,6 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve@1.1.x:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
-
 resolve@^1.2.0, resolve@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
@@ -3292,19 +3413,13 @@ source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
+source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
 source-map@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-
-source-map@~0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
-  dependencies:
-    amdefine ">=0.0.4"
-
-source-map@~0.5.1:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -3445,7 +3560,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.0:
+supports-color@^3.1.2:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
@@ -3546,6 +3661,10 @@ tmp@^0.0.31:
   dependencies:
     os-tmpdir "~1.0.1"
 
+to-fast-properties@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
 toml@^2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/toml/-/toml-2.3.3.tgz#8d683d729577cb286231dfc7a8affe58d31728fb"
@@ -3567,6 +3686,10 @@ tough-cookie@~2.3.3:
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:
     punycode "^1.4.1"
+
+trim-right@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
 tryit@^1.0.1:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -400,7 +400,7 @@ builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
-bunyan@^1.8.10, bunyan@^1.8.12:
+bunyan@^1.8.10:
   version "1.8.12"
   resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.12.tgz#f150f0f6748abdd72aeae84f04403be2ef113797"
   optionalDependencies:


### PR DESCRIPTION
If zero items are placed on the queue, the drain function does not fire.
Theses changes will call the 'drain' function if no items are queued to ensure normal processing continues.