### PR TITLE
Reinstate retry queue, upgrade to class based etl-toolkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.9.0 / TBA
+==================
+- Reinstate retry queue
+- Upgrade to class based etl-toolkit
+
 0.8.2 / 2018-05-16
 ==================
 - Reinstate update of seed ID list

--- a/app/lib/config.js
+++ b/app/lib/config.js
@@ -2,6 +2,7 @@ const version = require('../../package').version;
 
 module.exports = {
   containerName: process.env.CONTAINER_NAME || 'etl-output',
+  idKey: 'identifier',
   orgApiUrl: 'https://api.nhs.uk/organisations',
   outputDir: './output',
   outputFile: process.env.OUTPUT_FILE,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pharmacy-data-etl",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "ETL to extract data from Syndication/Organisations and store as JSON",
   "main": "app.js",
   "scripts": {
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "azure-data-service": "^0.3.0",
-    "etl-toolkit": "^0.2.0",
+    "etl-toolkit": "^0.3.0",
     "google-libphonenumber": "^3.0.3",
     "moment": "^2.20.1",
     "nhsuk-bunyan-logger": "^1.4.1",

--- a/test/integration/smartEtl.js
+++ b/test/integration/smartEtl.js
@@ -6,10 +6,10 @@ const nock = require('nock');
 const expect = chai.expect;
 
 const etl = require('../../app/lib/smartEtl');
-const etlStore = require('etl-toolkit').etlStore;
 const config = require('../../app/lib/config');
 
 const dateStampFormat = 'YYYYMMDD';
+const etlStore = etl.etlStore;
 
 function mockDataService(ids, data, idsDate, dataDate) {
   return {
@@ -159,7 +159,7 @@ describe('ETL', function test() {
 
     await etl.start(mockDataService(ids, data, idsDate, dataDate));
     expect(etlStore.getIds().length).to.equal(3);
-    expect(etlStore.getErorredIds().length).to.equal(2);
+    expect(etlStore.getErroredIds().length).to.equal(2);
     expect(etlStore.getRecord('one')).to.be.undefined;
     expect(etlStore.getRecord('two').name).to.equal('Two Updated');
     expect(etlStore.getRecord('three')).to.be.undefined;


### PR DESCRIPTION
Note: this PR will fail until 0.3.0 of the ETL toolkit is released.